### PR TITLE
商品詳細ページ税込表示訂正

### DIFF
--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -10,7 +10,7 @@
             <h3 class="font-weight-bold"><%= @item.name %></h3>
             <div class="mt-3 ml-3"><%= @item.description %></div>
             <div class="font-weight-bold mt-5 ml-3">
-              <%= number_to_currency(@item.excluding_tax_price, delimiter: ',', format: '¥ %n', precision: 0) %>(税込)
+              <%= number_to_currency(@item.excluding_tax_price * 1.1, delimiter: ',', format: '¥ %n', precision: 0) %>(税込)
             </div>
 
             <div class="form-group row float-right mt-5">


### PR DESCRIPTION
商品価格が税抜のままになっていたので、1.1倍するようにしました。